### PR TITLE
chore(conductor): workspace-currency setup (claude-kit #746)

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,9 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# Kit workspace-currency (claude-kit #746, personal-mode). New workspaces already
+# branch from origin/main, so they are born on the current kit. This setup script
+# keeps the long-lived ROOT checkout current too, because that root is the
+# /kit-sync source and the kit-drift reference. No file copy, no sync-kit here.
+# See .claude/specs/kit/session-isolation.md Layer 6.
+[scripts]
+setup = "git -C \"$CONDUCTOR_ROOT_PATH\" fetch --prune origin && git -C \"$CONDUCTOR_ROOT_PATH\" pull --ff-only || true"


### PR DESCRIPTION
Adds the Conductor workspace-currency setup so new workspaces are born on the current kit. claude-kit #746. See .claude/specs/kit/session-isolation.md Layer 6.